### PR TITLE
fix tfvars.mjs to use replace with regex instead of replaceAll

### DIFF
--- a/scripts/tfvars.mjs
+++ b/scripts/tfvars.mjs
@@ -147,7 +147,7 @@ async function devopsTFvars() {
 
   const githubUser = githubURL.split("/").reverse()[1];
 
-  const githubURLEscaped = githubURL.replaceAll("/", "\\/");
+  const githubURLEscaped = githubURL.replace(/\//g, "\\/");
   const replaceCmdURL = `s/GITHUB_REPOSITORY_URL/${githubURLEscaped}/`;
 
   try {


### PR DESCRIPTION
Some OCI Cloud Shells use Node 14. Node 14 does not support `replaceAll`.